### PR TITLE
doc(dakanji-RefindPlus): Remove obsolete build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,6 @@ sed -e 's/void[*] lodepng_refit_malloc/void* _dup_lodepng_refit_malloc/' \
     -e 's/void lodepng_refit_free/void _dup_lodepng_refit_free/' \
     -i-orig RefindPlusPkg/libeg/lodepng_xtra.c
 
-
-cat > RefindPlusPkg/build.sh <<EOF
-/home/edk2/entry.sh
-EOF
-chmod +x RefindPlusPkg/build.sh
-
 docker run --rm \
     -e CFLAGS=-Wno-error \
     -e TOOLCHAIN=CLANG38 \
@@ -87,7 +81,7 @@ docker run --rm \
     -e DSC_PATH=RefindPlusPkg/RefindPlusPkg.dsc \
     -v "$PWD/RefindPlusPkg/:/home/edk2/edk2/RefindPlusPkg/" \
     -v "$PWD/out:/home/edk2/Build" \
-    xaionaro2/edk2-builder:RefindPlusUDK /bin/bash /home/edk2/edk2/RefindPlusPkg/build.sh
+    xaionaro2/edk2-builder:RefindPlusUDK
 ```
 
 ### OVMF

--- a/examples/github.com-dakanji-RefindPlus/build.sh
+++ b/examples/github.com-dakanji-RefindPlus/build.sh
@@ -10,12 +10,6 @@ sed -e 's/void[*] lodepng_refit_malloc/void* _dup_lodepng_refit_malloc/' \
     -e 's/void lodepng_refit_free/void _dup_lodepng_refit_free/' \
     -i-orig RefindPlusPkg/libeg/lodepng_xtra.c
 
-
-cat > RefindPlusPkg/build.sh <<EOF
-/home/edk2/entry.sh
-EOF
-chmod +x RefindPlusPkg/build.sh
-
 docker run --rm \
     -e CFLAGS=-Wno-error \
     -e TOOLCHAIN=CLANG38 \
@@ -23,4 +17,4 @@ docker run --rm \
     -e DSC_PATH=RefindPlusPkg/RefindPlusPkg.dsc \
     -v "$PWD/RefindPlusPkg/:/home/edk2/edk2/RefindPlusPkg/" \
     -v "$PWD/out:/home/edk2/Build" \
-    xaionaro2/edk2-builder:RefindPlusUDK /bin/bash /home/edk2/edk2/RefindPlusPkg/build.sh
+    xaionaro2/edk2-builder:RefindPlusUDK


### PR DESCRIPTION
In https://github.com/xaionaro/edk2-builder-docker/pull/27 @startergo basically removed the reason of this `build.sh` file to exist. So removing it.